### PR TITLE
Makefile updated in order to better handle find

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ CXXFLAGS = -w -MD -MP
 #includes all folders, make it easier to #include headers
 INCLUDES = -I./include/SDL2 -I./src $(shell find src -type d -exec echo -I./{} \;)
 # Source files - now includes all cpp files in src and subdirectories
-SOURCES = $(shell find src -name '*.cpp')
+SOURCES = $(shell find src -name '*.cpp' -print0 | xargs -0)
 BUILD_DIR = bin
 WEB_DIR = web
 


### PR DESCRIPTION
The make command fails on some systems with a "no SOURCES found" error when using `SOURCES = $(shell find src -name '*.cpp')`. This is because different shells handle the newlines in the find command's output differently, causing the list of files to be improperly formatted.

To fix this, we can use method that handles the find output correctly:
`SOURCES = $(shell find src -name '*.cpp' -print0 | xargs -0)`

https://github.com/mauricioohse/rosengine-v3-tdd/issues/47